### PR TITLE
Implement Entropy Fix in AUSM+Up Scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,138 @@
 
 # Emacs backup files
 *~
+
+#########################################
+#   Metas
+#########################################
+.imageconf
+.vscode
+
+#########################################
+#   Compressed files
+#########################################
+*.zip
+*.tgz
+*.gz
+*.7z
+
+#########################################
+#   Images and videos
+#########################################
+**/*/*.png
+**/*/*.jpeg
+**/*/*.jpg
+**/*/*.tiff
+**/*/*.svg
+**/*/*.mp4
+**/*/*.avi
+**/*/*.wmv
+
+#########################################
+#   Python
+#########################################
+**/*/*pycache*
+*.venv
+*.pyc
+
+#########################################
+#   Geometry files
+#########################################
+**/*/*.stl
+**/*/*.fms
+**/*/*.obj
+**/*/*.vt*
+**/*/*.mtl
+
+#########################################
+#   Log and build files
+#########################################
+*out Create monthly report*
+*log*
+**/*/build
+**/*/old
+
+#########################################
+#   VS Code
+#########################################
+**/*/*.DS_Store
+**/*/*.Identifier
+
+#########################################
+#   OpenFOAM
+#########################################
+# Timestep directories
+**/*/0*
+!**/*/0.orig
+**/*/*e-0*
+**/*/*e-10
+**/*/[1-9]*
+**/*/backup*
+
+# Fields that must get ignored
+**/*/phi*
+**/*/meshPhi*
+
+# Decomposed domain
+**/*/processor*
+
+# logfiles
+log.*
+*log
+
+# paraview/ParaFoam
+**/*/*.foam
+**/*/*.OpenFOAM
+**/*/*.pvsm
+**/*/*VTK*
+
+# VTK
+**/VTK
+
+# mesh data that is no dictionary
+**/*/constant/polyMesh/points*
+**/*/constant/polyMesh/faces*
+**/*/constant/polyMesh/owner*
+**/*/constant/polyMesh/neighbour*
+**/*/constant/polyMesh/sets
+**/*/constant/polyMesh/*
+**/*/*polyMesh*
+**/*/*.msh
+**/*/*.nmf
+**/*/*.p3dfmt
+**/*/*.p2dfmt
+**/*/*.x.fmt
+
+# Zones and levels
+# *Level*
+# *Zone*
+
+# snappyHexMesh files that are not snappyHexMeshDict
+**/constant/polyMesh/refinementHistory*
+**/constant/polyMesh/surfaceIndex*
+**/constant/triSurface
+**/constant/extendedFeatureEdgeMesh
+**/*.obj
+
+# function object and post-processing data
+forces
+postProcessing
+
+# Needed when C++ code is built using the OpenFOAM library, since it does not
+# use a "normal" build tool (make, cmake, ..).
+lnInclude
+*.dep
+linux*
+Darwin*
+
+#########################################
+#  Exclude important folders and files
+#########################################
+#
+!**/*/constant/thermophysicalProperties
+!**/*/boundary
+!**/*/constant/turbulenceProperties
+!**/*/system
+!.gitignore
+!**/*/logging
+!**/*/FOs/forces

--- a/mySolvers/myDbns/dbnsFlux/AUSMplusUpFlux/AUSMplusUpFlux.C
+++ b/mySolvers/myDbns/dbnsFlux/AUSMplusUpFlux/AUSMplusUpFlux.C
@@ -37,11 +37,12 @@ namespace Foam
 Foam::AUSMplusUpFlux::AUSMplusUpFlux(const fvMesh&, const dictionary& dict)
 {
     dictionary mySubDict( dict.subOrEmptyDict("AUSMplusUpFluxCoeffs") );
-    beta_  = mySubDict.lookupOrAddDefault("beta", 1.0/8.0);
-    MaInf_ = mySubDict.lookupOrAddDefault("MaInf", 0.3);
-    Kp_    = mySubDict.lookupOrAddDefault("Kp", 0.25);
-    Ku_    = mySubDict.lookupOrAddDefault("Ku", 0.75);
-    sigma_ = mySubDict.lookupOrAddDefault("sigma", 1.0);
+    beta_    = mySubDict.lookupOrAddDefault("beta", 1.0/8.0);
+    MaInf_   = mySubDict.lookupOrAddDefault("MaInf", 0.3);
+    Kp_      = mySubDict.lookupOrAddDefault("Kp", 0.25);
+    Ku_      = mySubDict.lookupOrAddDefault("Ku", 0.75);
+    sigma_   = mySubDict.lookupOrAddDefault("sigma", 1.0);
+    deltaEF_ = mySubDict.lookupOrAddDefault("deltaEF", 1e-4);
     
     if (mySubDict.lookupOrDefault("printCoeffs", false))
         Info << mySubDict << nl;
@@ -103,7 +104,7 @@ void Foam::AUSMplusUpFlux::evaluateFlux
     const scalar aTilde = min(aHatLeft, aHatRight);
     const scalar rhoTilde = 0.5*(rhoLeft+rhoRight);
     
-    const scalar sqrMaDash = (sqr(qLeft)+sqr(qRight))/(2.0*sqr(aTilde));
+    const scalar sqrMaDash = ((sqr(qLeft)+sqr(qRight))/(2.0*sqr(aTilde))+deltaEF_)/(1+deltaEF_);
     const scalar sqrMaZero = min(1.0,max(sqrMaDash,sqr(MaInf_)));
     const scalar MaZero    = Foam::sqrt(sqrMaZero);
 
@@ -114,8 +115,8 @@ void Foam::AUSMplusUpFlux::evaluateFlux
     const scalar MaRelLeft  = qLeft /aTilde;
     const scalar MaRelRight = qRight/aTilde;
     
-    const scalar magMaRelLeft  = mag(MaRelLeft);
-    const scalar magMaRelRight = mag(MaRelRight);
+    const scalar magMaRelLeft  = (mag(MaRelLeft) +deltaEF_)/(1+deltaEF_);
+    const scalar magMaRelRight = (mag(MaRelRight)+deltaEF_)/(1+deltaEF_);
     
     const scalar Ma1PlusLeft   = 0.5*(MaRelLeft +magMaRelLeft );
     const scalar Ma1MinusRight = 0.5*(MaRelRight-magMaRelRight);

--- a/mySolvers/myDbns/dbnsFlux/AUSMplusUpFlux/AUSMplusUpFlux.H
+++ b/mySolvers/myDbns/dbnsFlux/AUSMplusUpFlux/AUSMplusUpFlux.H
@@ -102,6 +102,7 @@ private:
     scalar Kp_;
     scalar Ku_;
     scalar sigma_;
+    scalar deltaEF_;
 };
 
 


### PR DESCRIPTION
This update implements an entropy fix in the AUSM+Up flux scheme to address instabilities in rarefaction waves. Without this fix, expansion regions, such as those near sharp corners or rarefaction fans, may exhibit unphysical pressure and density drops. The entropy fix smooths the Mach number splitting near sonic conditions by introducing a parameter δ, which stabilizes transitions and ensures consistent flux balance.

This enhancement improves robustness in simulations with high-speed flows and large expansion gradients.
References:

    Liou, M.-S. (2006). "A Sequel to AUSM: AUSM+-up."
    Hirsch, C. (2007). Numerical Computation of Internal and External Flows.

Mathematically, the problem near $M=0$ arises because the standard Mach number splitting produces a non-differentiable term, leading to discontinuities in flux computations. These discontinuities destabilize the solver and amplify errors, especially in rarefactions.

The entropy fix modifies the splitting as:

$$
M^{\pm} = \frac{1}{2} \left ( M \pm \frac{\lvert M \rvert + \delta}{1 + \delta} \right ) ,
$$

where $δ>0$ (usually between 1e-3 and 1e-6). This smooths $|M|$ by ensuring a continuous derivative near $M=0$. It prevents singularities and stabilizes flux evaluations, particularly where the Mach number changes rapidly, such as in sonic or rarefaction regions.